### PR TITLE
Adds writeOut function and restructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,5 @@ node_js:
 install:
   - npm install
 script:
+  - npm run lint
   - npm test

--- a/index.js
+++ b/index.js
@@ -4,31 +4,30 @@
  * which also borrowed from gulp-jshint-xml-file-reporter
  * https://github.com/lourenzo/gulp-jshint-xml-file-reporter
  */
-'use strict';
 
-var fs = require('fs');
-var path = require('path');
-var mkdirp = require('mkdirp');
+const fs = require('fs');
+const path = require('path');
+const mkdirp = require('mkdirp');
 
 /**
  * Creates the output dir
  * @param {String} filePath
  * @param cb
  */
-var createDirectory = (filePath, cb) => {
-    var dirname = path.dirname(filePath);
+const createDirectory = (filePath, cb) => {
+  const dirname = path.dirname(filePath);
 
-    mkdirp(dirname, function (err) {
-        if (!err) {
-            cb();
-        } else {
-            console.error('Error creating directory: ', err);
-        }
-    });
+  mkdirp(dirname, (err) => {
+    if (!err) {
+      cb();
+    } else {
+      console.error('Error creating directory: ', err);
+    }
+  });
 };
 
-var reset = () => {
-    exports.out = [];
+const reset = () => {
+  exports.out = [];
 };
 reset();
 
@@ -36,7 +35,7 @@ reset();
  * Formats result into junit testcase format
  * @param {Object} result
  */
-var formatTestcase = (result) => {
+const formatTestcase = (result) => {
   const message = result.message.replace(/"/g, '&quot;');
   return `
     <testcase time="0" name="org.lesshint.${result.linter}">
@@ -68,18 +67,20 @@ exports.report = (results) => {
   // Group testcase by file name
   Object.keys(resultsByfiles).forEach((file) => {
     const count = resultsByfiles[file].length;
-    let suite = resultsByfiles[file].map(formatTestcase).join('');
+    const suite = resultsByfiles[file].map(formatTestcase).join('');
     output += `
   <testsuite package="org.lesshint" time="0" tests="${count}" errors="${count}" name="${file}">${suite}
   </testsuite>`;
   });
 
   if (output !== '') {
-    let xml = `<?xml version="1.0" encoding="utf-8"?>
+    const xml = `<?xml version="1.0" encoding="utf-8"?>
 <testsuites>
   ${output}
 </testsuites>`;
     exports.out.push(xml);
+    console.log(xml);
+    process.exit(1);
   }
 };
 
@@ -88,19 +89,17 @@ exports.report = (results) => {
  * @param {String} filePath
  */
 exports.writeOut = (filePath) => {
-    if (typeof filePath === 'string') {
-      return () => {
-          createDirectory(filePath, () => {
-              var outStream = fs.createWriteStream(filePath);
-              outStream.write(exports.out[0]);
-              reset();
-          });
-      };
-    }
-    else {
-      return () => {
-        console.log(exports.out[0]);
+  if (typeof filePath === 'string') {
+    return () => {
+      createDirectory(filePath, () => {
+        const outStream = fs.createWriteStream(filePath);
+        outStream.write(exports.out[0]);
         reset();
-      };
-    }
+      });
+    };
+  }
+  return () => {
+    console.log(exports.out[0]);
+    reset();
+  };
 };

--- a/index.js
+++ b/index.js
@@ -1,46 +1,106 @@
-module.exports = {
-  name: 'lesshint-reporter-junit',
-  report: (results) => {
-    const resultsByfiles = {};
-    let output = '';
+/**
+ * Additions for writing files borrowed/inspired by lesshint-lint-xml-reporter
+ * https://github.com/llaumgui/lesshint-lint-xml-reporter
+ * which also borrowed from gulp-jshint-xml-file-reporter
+ * https://github.com/lourenzo/gulp-jshint-xml-file-reporter
+ */
+'use strict';
 
-    // Grab each result and key by file name
-    results.forEach((result) => {
-      if (typeof resultsByfiles[result.fullPath] === 'undefined') {
-        resultsByfiles[result.fullPath] = [];
-      }
+var fs = require('fs');
+var path = require('path');
+var mkdirp = require('mkdirp');
 
-      resultsByfiles[result.fullPath].push(result);
+/**
+ * Creates the output dir
+ * @param {String} filePath
+ * @param cb
+ */
+var createDirectory = (filePath, cb) => {
+    var dirname = path.dirname(filePath);
+
+    mkdirp(dirname, function (err) {
+        if (!err) {
+            cb();
+        } else {
+            console.error('Error creating directory: ', err);
+        }
     });
+};
 
-    // Group testcase by file name
-    Object.keys(resultsByfiles).forEach((file) => {
-      const count = resultsByfiles[file].length;
+var reset = () => {
+    exports.out = [];
+};
+reset();
 
-      output += `<testsuite package="org.lesshint" time="0" tests="${count}" errors="${count}" name="${file}">`;
+/**
+ * Formats result into junit testcase format
+ * @param {Object} result
+ */
+var formatTestcase = (result) => {
+  const message = result.message.replace(/"/g, '&quot;');
+  return `
+    <testcase time="0" name="org.lesshint.${result.linter}">
+      <failure message="${message}">
+        <![CDATA[line ${result.line}, col ${result.column}, ${message} (${result.linter})]]>
+      </failure>
+    </testcase>`;
+};
 
-      resultsByfiles[file].forEach((result) => {
-        const message = result.message.replace(/"/g, '&quot;');
+exports.name = 'lesshint-lint-junit-reporter';
 
-        output += `<testcase time="0" name="org.lesshint.${result.linter}">`;
-        output += `<failure message="${message}">`;
-        output += `<![CDATA[line ${result.line}, col ${result.column}, ${message} (${result.linter})]]>`;
-        output += '</failure>';
-        output += '</testcase>';
-      });
+/**
+ * Processes results into a junit report.
+ * @param {Array} results
+ */
+exports.report = (results) => {
+  const resultsByfiles = {};
+  let output = '';
 
-      output += '</testsuite>';
-    });
-
-    if (output !== '') {
-      let xml = '';
-      xml += '<?xml version="1.0" encoding="utf-8"?>';
-      xml += '<testsuites>';
-      xml += output;
-      xml += '</testsuites>';
-
-      console.log(xml);
-      process.exit(1);
+  // Grab each result and key by file name
+  results.forEach((result) => {
+    if (typeof resultsByfiles[result.fullPath] === 'undefined') {
+      resultsByfiles[result.fullPath] = [];
     }
-  },
+
+    resultsByfiles[result.fullPath].push(result);
+  });
+
+  // Group testcase by file name
+  Object.keys(resultsByfiles).forEach((file) => {
+    const count = resultsByfiles[file].length;
+    let suite = resultsByfiles[file].map(formatTestcase).join('');
+    output += `
+  <testsuite package="org.lesshint" time="0" tests="${count}" errors="${count}" name="${file}">${suite}
+  </testsuite>`;
+  });
+
+  if (output !== '') {
+    let xml = `<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+  ${output}
+</testsuites>`;
+    exports.out.push(xml);
+  }
+};
+
+/**
+ * Writes output to file if filePath is defined. Otherwise it outputs to console.log
+ * @param {String} filePath
+ */
+exports.writeOut = (filePath) => {
+    if (typeof filePath === 'string') {
+      return () => {
+          createDirectory(filePath, () => {
+              var outStream = fs.createWriteStream(filePath);
+              outStream.write(exports.out[0]);
+              reset();
+          });
+      };
+    }
+    else {
+      return () => {
+        console.log(exports.out[0]);
+        reset();
+      };
+    }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lesshint-reporter-junit",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Lesshint JUNIT compatible reporter",
   "main": "index.js",
   "repository": "https://github.com/drinkataco/lesshint-reporter-junit.git",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "eslint-plugin-import": "^2.13.0",
     "eslint-plugin-mocha": "^5.1.0",
     "mocha": "^5.2.0",
+    "sinon": "^6.3.4",
     "test-console": "^1.1.0",
     "xml2js": "^0.4.19"
   },

--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
     "mocha": "^5.2.0",
     "test-console": "^1.1.0",
     "xml2js": "^0.4.19"
+  },
+  "dependencies": {
+    "mkdirp": "^0.5.1"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -46,8 +46,6 @@ const exampleResults = [
   },
 ];
 
-// Capture exit process method
-
 describe('JUNIT Reporter', () => {
   it('It should parse errors and throw exit code', (done) => {
     sinon.stub(process, 'exit');
@@ -57,7 +55,7 @@ describe('JUNIT Reporter', () => {
 
     inspect.restore();
 
-    // Start by checking the exist code so we can restore process.exit
+    // Start by checking the exit code so we can restore process.exit
     assert.ok(process.exit.calledWith(1));
     process.exit.restore();
     const response = inspect.output;
@@ -95,7 +93,7 @@ describe('JUNIT Reporter', () => {
     junitReporter.report([]);
 
     inspect.restore();
-    // Start by checking the exist code so we can restore process.exit
+    // Start by checking the exit code so we can restore process.exit
     assert.ok(!process.exit.called);
     process.exit.restore();
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 const assert = require('assert');
 const xml2js = require('xml2js');
+const fs = require('fs');
 const { stdout } = require('test-console');
 
 const junitReporter = require('../index');
@@ -76,9 +77,9 @@ describe('JUNIT Reporter', () => {
       assert.ok(anotherFile.$.errors === '1');
       assert.ok(anotherFile.testcase.length === parseInt(anotherFile.$.errors, 10));
 
-      assert.ok(testFile.testcase[0].failure[0]._ === 'line 4, col 5, The universal selector shouldn\'t be used. (universalSelector)');
-      assert.ok(testFile.testcase[1].failure[0]._ === 'line 5, col 17, Unit should not be omitted on zero values. (zeroUnit)');
-      assert.ok(anotherFile.testcase[0].failure[0]._ === 'line 6, col 9, Property ordering is not alphabetized (propertyOrdering)');
+      assert.ok(testFile.testcase[0].failure[0]._.trim() === 'line 4, col 5, The universal selector shouldn\'t be used. (universalSelector)');
+      assert.ok(testFile.testcase[1].failure[0]._.trim() === 'line 5, col 17, Unit should not be omitted on zero values. (zeroUnit)');
+      assert.ok(anotherFile.testcase[0].failure[0]._.trim() === 'line 6, col 9, Property ordering is not alphabetized (propertyOrdering)');
 
       assert.ok(exitCode === 1);
       exitCode = null;
@@ -98,6 +99,25 @@ describe('JUNIT Reporter', () => {
     assert.ok(response.length === 0);
 
     assert.ok(exitCode === null);
+    done();
+  });
+
+  it('It should be able to write to file', (done) => {
+    const filename = 'junit.xml';
+    const inspect = stdout.inspect();
+
+    junitReporter.report(exampleResults);
+
+    const writeOut = junitReporter.writeOut(filename);
+    writeOut();
+
+    inspect.restore();
+    // Wait 100 ms before checking if file exists, as writeOut is asynchronous
+    setTimeout(() => {
+      assert.ok(fs.existsSync(filename));
+      // Then delete the file
+      fs.unlinkSync(filename);
+    }, 100);
     done();
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -107,14 +107,20 @@ describe('JUNIT Reporter', () => {
     const inspect = stdout.inspect();
 
     junitReporter.report(exampleResults);
+    const output = junitReporter.out[0];
 
     const writeOut = junitReporter.writeOut(filename);
     writeOut();
 
     inspect.restore();
+
     // Wait 100 ms before checking if file exists, as writeOut is asynchronous
     setTimeout(() => {
       assert.ok(fs.existsSync(filename));
+      // Assert that the file contets match the output
+      assert.ok(fs.readFileSync(filename, { encoding: 'utf-8' }) === output);
+      // writeOut should have reset the junitReporter.out array
+      assert.ok(junitReporter.out[0] === undefined);
       // Then delete the file
       fs.unlinkSync(filename);
     }, 100);

--- a/test/test.js
+++ b/test/test.js
@@ -113,13 +113,13 @@ describe('JUNIT Reporter', () => {
     const output = junitReporter.out[0];
 
     const writeOut = junitReporter.writeOut(filename);
-    writeOut();
+    const writePromise = new Promise(() => {
+      writeOut();
 
-    inspect.restore();
-    process.exit.restore();
-
-    // Wait 100 ms before checking if file exists, as writeOut is asynchronous
-    setTimeout(() => {
+      inspect.restore();
+      process.exit.restore();
+    });
+    writePromise.then(() => {
       assert.ok(fs.existsSync(filename));
       // Assert that the file contets match the output
       assert.ok(fs.readFileSync(filename, { encoding: 'utf-8' }) === output);
@@ -127,7 +127,7 @@ describe('JUNIT Reporter', () => {
       assert.ok(junitReporter.out[0] === undefined);
       // Then delete the file
       fs.unlinkSync(filename);
-    }, 100);
+    });
     done();
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,30 @@
 # yarn lockfile v1
 
 
+"@sinonjs/commons@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.0.2.tgz#3e0ac737781627b8844257fadc3d803997d0526e"
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/formatio@3.0.0", "@sinonjs/formatio@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-3.0.0.tgz#9d282d81030a03a03fa0c5ce31fd8786a4da311a"
+  dependencies:
+    "@sinonjs/samsam" "2.1.0"
+
+"@sinonjs/samsam@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-2.1.0.tgz#b8b8f5b819605bd63601a6ede459156880f38ea3"
+  dependencies:
+    array-from "^2.1.1"
+
+"@sinonjs/samsam@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-2.1.1.tgz#f352621c24c9e9ab2ed293a7655e8d46bfd64c16"
+  dependencies:
+    array-from "^2.1.1"
+
 acorn-jsx@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
@@ -56,6 +80,10 @@ argparse@^1.0.7:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
   dependencies:
     sprintf-js "~1.0.2"
+
+array-from@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/array-from/-/array-from-2.1.1.tgz#cfe9d8c26628b9dc5aecc62a9f5d8f1f352c1195"
 
 array-union@^1.0.1:
   version "1.0.2"
@@ -230,7 +258,7 @@ del@^2.0.2:
     pinkie-promise "^2.0.0"
     rimraf "^2.2.8"
 
-diff@3.5.0:
+diff@3.5.0, diff@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
 
@@ -640,6 +668,10 @@ is-symbol@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.1.tgz#3cc59f00025194b6ab2e38dbae6689256b660572"
 
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+
 isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -667,6 +699,10 @@ json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
 
+just-extend@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-3.0.0.tgz#cee004031eaabf6406da03a7b84e4fe9d78ef288"
+
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
@@ -690,9 +726,17 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+
 lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
+
+lolex@^2.3.2, lolex@^2.7.4:
+  version "2.7.5"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.7.5.tgz#113001d56bfc7e02d56e36291cc5c413d1aa0733"
 
 lru-cache@^4.0.1:
   version "4.1.3"
@@ -715,13 +759,7 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-mkdirp@0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
-  dependencies:
-    minimist "0.0.8"
-
-mkdirp@^0.5.1:
+mkdirp@0.5.1, mkdirp@^0.5.1:
   version "0.5.1"
   resolved "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -754,6 +792,16 @@ mute-stream@0.0.7:
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+
+nise@^1.4.5:
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-1.4.5.tgz#979a97a19c48d627bb53703726ae8d53ce8d4b3e"
+  dependencies:
+    "@sinonjs/formatio" "3.0.0"
+    just-extend "^3.0.0"
+    lolex "^2.3.2"
+    path-to-regexp "^1.7.0"
+    text-encoding "^0.6.4"
 
 normalize-package-data@^2.3.2:
   version "2.4.0"
@@ -860,6 +908,12 @@ path-is-inside@^1.0.1, path-is-inside@^1.0.2:
 path-parse@^1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
+
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^2.0.0:
   version "2.0.0"
@@ -1018,6 +1072,20 @@ signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
+sinon@^6.3.4:
+  version "6.3.4"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-6.3.4.tgz#6f076d7ddcf381af6c16468ac83d30333a756ec8"
+  dependencies:
+    "@sinonjs/commons" "^1.0.2"
+    "@sinonjs/formatio" "^3.0.0"
+    "@sinonjs/samsam" "^2.1.1"
+    diff "^3.5.0"
+    lodash.get "^4.4.2"
+    lolex "^2.7.4"
+    nise "^1.4.5"
+    supports-color "^5.5.0"
+    type-detect "^4.0.8"
+
 slice-ansi@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-1.0.0.tgz#044f1a49d8842ff307aad6b505ed178bd950134d"
@@ -1093,6 +1161,12 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
+supports-color@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
+  dependencies:
+    has-flag "^3.0.0"
+
 table@4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/table/-/table-4.0.2.tgz#a33447375391e766ad34d3486e6e2aedc84d2e36"
@@ -1107,6 +1181,10 @@ table@4.0.2:
 test-console@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/test-console/-/test-console-1.1.0.tgz#34466d421f1b049e1be80d1734bdb5a512889c7f"
+
+text-encoding@^0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
 
 text-table@~0.2.0:
   version "0.2.0"
@@ -1127,6 +1205,10 @@ type-check@~0.3.2:
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
   dependencies:
     prelude-ls "~1.1.2"
+
+type-detect@4.0.8, type-detect@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
 
 typedarray@^0.0.6:
   version "0.0.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -715,9 +715,15 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-mkdirp@0.5.1, mkdirp@^0.5.1:
+mkdirp@0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
+  dependencies:
+    minimist "0.0.8"
+
+mkdirp@^0.5.1:
+  version "0.5.1"
+  resolved "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
 


### PR DESCRIPTION
## Premise
I wanted to write junit reports to a file using gulp-lesshint so only logging to console was not optimal. So I looked at the behaviour of other reporters (lesshint-lint-xml-reporter, which borrowed from gulp-jshint-xml-file-reporter) and added that functionality.

## Changes
- Adds writeOut function, which writes out to file if filePath is given. Otherwise to console.
- comment and restructure module
- update version